### PR TITLE
Nessus manager deployment shouldn't be triggered;

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -4,7 +4,6 @@ jobs:
   - aggregate:
     - get: master-bosh-root-cert
     - get: nessus-manager-config
-      trigger: true
     - get: common-prod
     - get: cg-s3-nessus-manager-release
     - get: nessus-manager-stemcell


### PR DESCRIPTION
A deployment of the Nessus Manager _needs to be carefully applied_ and
should be done with a human operator at the button.

![the agent was successfully linked](https://user-images.githubusercontent.com/706004/27061973-dcb48bb8-4fb5-11e7-840f-e3f9e5694873.jpg)
